### PR TITLE
update parseConcat to fix regex statement

### DIFF
--- a/Dongle.php
+++ b/Dongle.php
@@ -106,7 +106,7 @@ class Dongle
      */
     public function parseConcat($sql)
     {
-        return preg_replace_callback('/(?:group_)?concat\(([^)]+)\)(?R)/i', function($matches){
+        return preg_replace_callback('/(?:group_)?concat\(([^)]+)\)(?R)?/i', function($matches){
             if (!isset($matches[1])) {
                 return $matches[0];
             }


### PR DESCRIPTION
Original pattern did not match "concat(first_name, ' ', last_name)". Throws Exception by visiting backend/backend/users with database driver other than MySQL. Fixed by testing with: https://www.regex101.com/r/mE7bX6/1
